### PR TITLE
Fix compilation with C++ 17

### DIFF
--- a/src/MeshProjector.cc
+++ b/src/MeshProjector.cc
@@ -6,6 +6,7 @@
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <random>
 
 #include <Eigen/Dense>
 
@@ -185,7 +186,7 @@ void MeshProjector::ComputeIndependentSet() {
 				group.push_back(i);
 				marked_vertices += 1;
 			}
-			std::random_shuffle(group.begin(), group.end());
+			std::shuffle(group.begin(), group.end(), std::mt19937(std::random_device()()));
 		}
 		group_id += 1;
 	}	


### PR DESCRIPTION
`MeshProjector.cc` uses `std::random_shuffle()` that was [deprecated in C++14 and removed in C++17](https://en.cppreference.com/w/cpp/algorithm/random_shuffle).
It can be replaced by `std::shuffle()` used with a random generator such as [std::mt19937()](https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine) (both available in C++11).